### PR TITLE
feat: 모집 지원 거절

### DIFF
--- a/common/src/main/java/com/paassible/common/response/ErrorCode.java
+++ b/common/src/main/java/com/paassible/common/response/ErrorCode.java
@@ -57,9 +57,9 @@ public enum ErrorCode implements BaseResponseCode {
     COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "P009", "댓글 삭제 권한이 없습니다."),
 
     APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "A001", "이미 신청한 지원입니다."),
-    APPLICATION_UNAUTHORIZED(HttpStatus.FORBIDDEN, "A002", "지원 내역에 접근할 권한이 없습니다."),
-
-
+    APPLICATION_UNAUTHORIZED(HttpStatus.FORBIDDEN, "A002", "해당 게시글의 지원자 관련 기능에 접근할 권한이 없습니다."),
+    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "A003", "존재하지 않는 지원입니다."),
+    APPLICATION_MISMATCH(HttpStatus.BAD_REQUEST, "A004", "해당 모집글의 지원이 아닙니다."),
 
     //meet
     MEET_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 회의입니다."),

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/controll/ApplicationController.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/controll/ApplicationController.java
@@ -4,7 +4,9 @@ import com.paassible.common.response.ApiResponse;
 import com.paassible.common.response.SuccessCode;
 import com.paassible.common.security.dto.UserJwtDto;
 import com.paassible.recruitservice.application.dto.ApplicantResponse;
+import com.paassible.recruitservice.application.dto.RejectRequest;
 import com.paassible.recruitservice.application.service.ApplicantionService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,6 +22,7 @@ public class ApplicationController {
 
     private final ApplicantionService applicantionService;
 
+    @Operation(summary = "지원하기")
     @PostMapping("/{postId}/applications")
     public ApiResponse<Void> apply(
             @PathVariable Long postId,
@@ -28,12 +31,24 @@ public class ApplicationController {
         return ApiResponse.success(SuccessCode.CREATED);
     }
 
+    @Operation(summary = "지원 조회")
     @GetMapping("/{postId}/applications")
     public ApiResponse<List<ApplicantResponse>> getApplicants(
             @PathVariable Long postId,
             @AuthenticationPrincipal UserJwtDto user){
         List<ApplicantResponse> response = applicantionService.getApplicants(postId,user.getUserId());
         return ApiResponse.success(SuccessCode.OK, response);
+    }
+
+    @Operation(summary = "지원 거절")
+    @PostMapping("/{postId}/applicants/{applicantId}/reject")
+    public ApiResponse<Void> rejectApplication(
+            @PathVariable Long postId,
+            @PathVariable Long applicantId,
+            @AuthenticationPrincipal UserJwtDto user,
+            @RequestBody RejectRequest request){
+        applicantionService.reject(postId,applicantId, request, user.getUserId());
+        return ApiResponse.success(SuccessCode.OK);
     }
 
 }

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/dto/RejectRequest.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/dto/RejectRequest.java
@@ -1,0 +1,7 @@
+package com.paassible.recruitservice.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RejectRequest(
+        @NotBlank String rejectReason
+){}

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/entity/Application.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/entity/Application.java
@@ -1,5 +1,6 @@
 package com.paassible.recruitservice.application.entity;
 
+import com.paassible.recruitservice.application.dto.RejectRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -40,9 +41,9 @@ public class Application {
         this.status = ApplicationStatus.ACCEPTED;
     }
 
-    public void reject(String reason) {
+    public void reject(RejectRequest reason) {
         this.status = ApplicationStatus.REJECTED;
-        this.rejectReason = reason;
+        this.rejectReason = reason.rejectReason();
     }
 
 }

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/service/ApplicantionService.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/service/ApplicantionService.java
@@ -3,6 +3,7 @@ package com.paassible.recruitservice.application.service;
 import com.paassible.common.exception.CustomException;
 import com.paassible.common.response.ErrorCode;
 import com.paassible.recruitservice.application.dto.ApplicantResponse;
+import com.paassible.recruitservice.application.dto.RejectRequest;
 import com.paassible.recruitservice.application.entity.Application;
 import com.paassible.recruitservice.application.entity.ApplicationStatus;
 import com.paassible.recruitservice.application.repository.ApplicantionRepository;
@@ -50,8 +51,24 @@ public class ApplicantionService {
                 .map(ApplicantResponse::from)
                 .toList();
 
+    }
 
+    @Transactional
+    public void reject(Long postId, Long applicantId, RejectRequest rejectRequest, Long userId){
+        Post post = postRepository.findById(postId)
+                .orElseThrow(()->new CustomException(ErrorCode.POST_NOT_FOUND));
 
+        if(!post.getWriterId().equals(userId)){
+            throw new CustomException(ErrorCode.APPLICATION_UNAUTHORIZED);
+        }
+
+        Application application = applicantionRepository.findById(applicantId)
+                .orElseThrow(()->new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
+        if(!application.getPostId().equals(postId)){
+            throw new CustomException(ErrorCode.APPLICATION_MISMATCH);
+        }
+
+        application.reject(rejectRequest);
     }
 
 

--- a/recruit-service/src/main/java/com/paassible/recruitservice/position/service/PositionService.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/position/service/PositionService.java
@@ -25,7 +25,7 @@ public class PositionService {
     @Transactional(readOnly = true)
     public String getPositionNameById(Long positionId) {
         Position position = positionRepository.findById(positionId)
-                .orElseThrow(() -> new CustomException(ErrorCode.POSITION_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_POSITION));
         return position.getName();
     }
 }


### PR DESCRIPTION
Ref : #49

### 🔍️ 이번 PR의 목적
- recruit 도메인의 모집 지원 거절 기능 구현

### ✨ 핵심 변경 내용
- common에 모집 지원 거절 관련 에러 코드 추가
- 모집 지원 거절 기능 추가

### 📝 기타 참고 사항
- 포지션 없을 때 ErrorCode.POSITION_NOT_FOUND에러 대신 기존에 존재하던 ErrorCode.INVALID_POSITION 사용하도록 수정 ( POSITION_NOT_FOUND가 등록되어있지 않아서 에러가 났음)
