### PR TITLE
Feat/53 application accept

### DIFF
--- a/board-service/src/main/java/com/paassible/boardservice/board/controller/BoardInternalController.java
+++ b/board-service/src/main/java/com/paassible/boardservice/board/controller/BoardInternalController.java
@@ -25,7 +25,7 @@ public class BoardInternalController {
     @Hidden
     @GetMapping("/{boardId}/user/{userId}/exists")
     public void existUserInBoard(@PathVariable Long boardId, @PathVariable Long userId) {
-        boardMemberService.validateUserInBoard(boardId,userId);
+        boardMemberService.validateUserInBoard(userId,boardId);
     }
 
     @Hidden

--- a/board-service/src/main/java/com/paassible/boardservice/board/controller/BoardInternalController.java
+++ b/board-service/src/main/java/com/paassible/boardservice/board/controller/BoardInternalController.java
@@ -27,4 +27,13 @@ public class BoardInternalController {
     public void existUserInBoard(@PathVariable Long boardId, @PathVariable Long userId) {
         boardMemberService.validateUserInBoard(boardId,userId);
     }
+
+    @Hidden
+    @PostMapping("/{boardId}/members")
+    public void addMember(
+            @PathVariable Long boardId, @RequestParam Long userId) {
+        boardMemberService.assignUserToBoard(userId, boardId);
+    }
+
+
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -35,4 +35,11 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.3"
+    }
 }

--- a/common/src/main/java/com/paassible/common/exception/FeignClientErrorDecoder.java
+++ b/common/src/main/java/com/paassible/common/exception/FeignClientErrorDecoder.java
@@ -1,0 +1,36 @@
+package com.paassible.common.exception;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.paassible.common.response.ErrorCode;
+import feign.Response;
+import feign.Util;
+import feign.codec.ErrorDecoder;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class FeignClientErrorDecoder implements ErrorDecoder {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        try {
+
+            String body = Util.toString(response.body().asReader(StandardCharsets.UTF_8));
+
+            JsonNode root = objectMapper.readTree(body);
+            String errorCodeStr = root.path("code").asText();
+
+            ErrorCode errorCode = ErrorCode.fromCode(errorCodeStr);
+
+            return new CustomException(errorCode);
+        } catch (Exception e) {
+            return new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}
+

--- a/common/src/main/java/com/paassible/common/response/ErrorCode.java
+++ b/common/src/main/java/com/paassible/common/response/ErrorCode.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+import java.util.Arrays;
+
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode implements BaseResponseCode {
@@ -75,4 +77,11 @@ public enum ErrorCode implements BaseResponseCode {
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;
+
+    public static ErrorCode fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(e -> e.getCode().equals(code))
+                .findFirst()
+                .orElse(INTERNAL_SERVER_ERROR);
+    }
 }

--- a/common/src/main/java/com/paassible/common/response/ErrorCode.java
+++ b/common/src/main/java/com/paassible/common/response/ErrorCode.java
@@ -57,9 +57,9 @@ public enum ErrorCode implements BaseResponseCode {
     COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "P009", "댓글 삭제 권한이 없습니다."),
 
     APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "A001", "이미 신청한 지원입니다."),
-    APPLICATION_UNAUTHORIZED(HttpStatus.FORBIDDEN, "A002", "지원 내역에 접근할 권한이 없습니다."),
-
-
+    APPLICATION_UNAUTHORIZED(HttpStatus.FORBIDDEN, "A002", "해당 게시글의 지원자 관련 기능에 접근할 권한이 없습니다."),
+    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "A003", "존재하지 않는 지원입니다."),
+    APPLICATION_MISMATCH(HttpStatus.BAD_REQUEST, "A004", "해당 모집글의 지원이 아닙니다."),
 
     //meet
     MEET_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 회의입니다."),

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/controll/ApplicationController.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/controll/ApplicationController.java
@@ -4,7 +4,9 @@ import com.paassible.common.response.ApiResponse;
 import com.paassible.common.response.SuccessCode;
 import com.paassible.common.security.dto.UserJwtDto;
 import com.paassible.recruitservice.application.dto.ApplicantResponse;
+import com.paassible.recruitservice.application.dto.RejectRequest;
 import com.paassible.recruitservice.application.service.ApplicantionService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,6 +22,7 @@ public class ApplicationController {
 
     private final ApplicantionService applicantionService;
 
+    @Operation(summary = "지원하기")
     @PostMapping("/{postId}/applications")
     public ApiResponse<Void> apply(
             @PathVariable Long postId,
@@ -28,12 +31,24 @@ public class ApplicationController {
         return ApiResponse.success(SuccessCode.CREATED);
     }
 
+    @Operation(summary = "지원 조회")
     @GetMapping("/{postId}/applications")
     public ApiResponse<List<ApplicantResponse>> getApplicants(
             @PathVariable Long postId,
             @AuthenticationPrincipal UserJwtDto user){
         List<ApplicantResponse> response = applicantionService.getApplicants(postId,user.getUserId());
         return ApiResponse.success(SuccessCode.OK, response);
+    }
+
+    @Operation(summary = "지원 거절")
+    @PostMapping("/{postId}/applicants/{applicantId}/reject")
+    public ApiResponse<Void> rejectApplication(
+            @PathVariable Long postId,
+            @PathVariable Long applicantId,
+            @AuthenticationPrincipal UserJwtDto user,
+            @RequestBody RejectRequest request){
+        applicantionService.reject(postId,applicantId, request, user.getUserId());
+        return ApiResponse.success(SuccessCode.OK);
     }
 
 }

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/controll/ApplicationController.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/controll/ApplicationController.java
@@ -3,6 +3,7 @@ package com.paassible.recruitservice.application.controll;
 import com.paassible.common.response.ApiResponse;
 import com.paassible.common.response.SuccessCode;
 import com.paassible.common.security.dto.UserJwtDto;
+import com.paassible.recruitservice.application.dto.AcceptRequest;
 import com.paassible.recruitservice.application.dto.ApplicantResponse;
 import com.paassible.recruitservice.application.dto.RejectRequest;
 import com.paassible.recruitservice.application.service.ApplicantionService;
@@ -20,14 +21,14 @@ import java.util.List;
 @Tag(name = "팀원 모집 지원 API", description = "팀원 모집 지원, 조회, 수락, 거절")
 public class ApplicationController {
 
-    private final ApplicantionService applicantionService;
+    private final ApplicantionService applicationService;
 
     @Operation(summary = "지원하기")
     @PostMapping("/{postId}/applications")
     public ApiResponse<Void> apply(
             @PathVariable Long postId,
             @AuthenticationPrincipal UserJwtDto user){
-        applicantionService.apply(postId, user.getUserId());
+        applicationService.apply(postId, user.getUserId());
         return ApiResponse.success(SuccessCode.CREATED);
     }
 
@@ -36,19 +37,32 @@ public class ApplicationController {
     public ApiResponse<List<ApplicantResponse>> getApplicants(
             @PathVariable Long postId,
             @AuthenticationPrincipal UserJwtDto user){
-        List<ApplicantResponse> response = applicantionService.getApplicants(postId,user.getUserId());
+        List<ApplicantResponse> response = applicationService.getApplicants(postId,user.getUserId());
         return ApiResponse.success(SuccessCode.OK, response);
     }
 
     @Operation(summary = "지원 거절")
     @PostMapping("/{postId}/applicants/{applicantId}/reject")
     public ApiResponse<Void> rejectApplication(
-            @PathVariable Long postId,
-            @PathVariable Long applicantId,
+            @PathVariable("postId") Long postId,
+            @PathVariable("applicantId") Long applicantId,
             @AuthenticationPrincipal UserJwtDto user,
             @RequestBody RejectRequest request){
-        applicantionService.reject(postId,applicantId, request, user.getUserId());
+        applicationService.reject(postId,applicantId, request, user.getUserId());
         return ApiResponse.success(SuccessCode.OK);
     }
+
+    @Operation(summary = "지원 수락")
+    @PostMapping("/{postId}/applications/{applicationId}/accept")
+    public ApiResponse<Void> acceptApplication(
+            @PathVariable Long postId,
+            @PathVariable Long applicationId,
+            @AuthenticationPrincipal UserJwtDto user,
+            @RequestBody AcceptRequest request
+    ) {
+        applicationService.accept(postId, applicationId, user.getUserId(), request);
+        return ApiResponse.success(SuccessCode.OK);
+    }
+
 
 }

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/dto/AcceptRequest.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/dto/AcceptRequest.java
@@ -1,0 +1,4 @@
+package com.paassible.recruitservice.application.dto;
+
+public record AcceptRequest(Long boardId) {}
+

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/dto/RejectRequest.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/dto/RejectRequest.java
@@ -1,0 +1,7 @@
+package com.paassible.recruitservice.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RejectRequest(
+        @NotBlank String rejectReason
+){}

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/entity/Application.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/entity/Application.java
@@ -33,10 +33,6 @@ public class Application {
         return new Application(postId, userId);
     }
 
-    public void updateStatus(ApplicationStatus status) {
-        this.status = status;
-    }
-
     public void accept() {
         this.status = ApplicationStatus.ACCEPTED;
     }

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/entity/Application.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/entity/Application.java
@@ -1,5 +1,6 @@
 package com.paassible.recruitservice.application.entity;
 
+import com.paassible.recruitservice.application.dto.RejectRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -40,9 +41,9 @@ public class Application {
         this.status = ApplicationStatus.ACCEPTED;
     }
 
-    public void reject(String reason) {
+    public void reject(RejectRequest reason) {
         this.status = ApplicationStatus.REJECTED;
-        this.rejectReason = reason;
+        this.rejectReason = reason.rejectReason();
     }
 
 }

--- a/recruit-service/src/main/java/com/paassible/recruitservice/application/service/ApplicantionService.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/application/service/ApplicantionService.java
@@ -3,6 +3,7 @@ package com.paassible.recruitservice.application.service;
 import com.paassible.common.exception.CustomException;
 import com.paassible.common.response.ErrorCode;
 import com.paassible.recruitservice.application.dto.ApplicantResponse;
+import com.paassible.recruitservice.application.dto.RejectRequest;
 import com.paassible.recruitservice.application.entity.Application;
 import com.paassible.recruitservice.application.entity.ApplicationStatus;
 import com.paassible.recruitservice.application.repository.ApplicantionRepository;
@@ -50,8 +51,24 @@ public class ApplicantionService {
                 .map(ApplicantResponse::from)
                 .toList();
 
+    }
 
+    @Transactional
+    public void reject(Long postId, Long applicantId, RejectRequest rejectRequest, Long userId){
+        Post post = postRepository.findById(postId)
+                .orElseThrow(()->new CustomException(ErrorCode.POST_NOT_FOUND));
 
+        if(!post.getWriterId().equals(userId)){
+            throw new CustomException(ErrorCode.APPLICATION_UNAUTHORIZED);
+        }
+
+        Application application = applicantionRepository.findById(applicantId)
+                .orElseThrow(()->new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
+        if(!application.getPostId().equals(postId)){
+            throw new CustomException(ErrorCode.APPLICATION_MISMATCH);
+        }
+
+        application.reject(rejectRequest);
     }
 
 

--- a/recruit-service/src/main/java/com/paassible/recruitservice/client/BoardClient.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/client/BoardClient.java
@@ -1,0 +1,22 @@
+package com.paassible.recruitservice.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
+
+@FeignClient(name = "board-service", url = "${board-service.url}")
+public interface BoardClient {
+
+    @PostMapping("/boards/internal/{boardId}/members")
+    void addMember(@PathVariable Long boardId,
+                                  @RequestParam Long userId);
+
+
+    @GetMapping("/boards/internal/{boardId}/user/{userId}/exists")
+    void existUserInBoard(@PathVariable Long boardId, @PathVariable Long userId);
+
+}

--- a/recruit-service/src/main/java/com/paassible/recruitservice/config/SecurityConfig.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/config/SecurityConfig.java
@@ -39,10 +39,10 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/recruit/swagger-ui/**",
-                                "/recruit/v3/api-docs/**"
+                                "/recruits/swagger-ui/**",
+                                "/recruits/v3/api-docs/**"
                         ).permitAll()
-                        .requestMatchers("/recruit/**").authenticated()
+                        .requestMatchers("/recruits/**").authenticated()
                         .anyRequest().permitAll()
                 )
 

--- a/recruit-service/src/main/java/com/paassible/recruitservice/position/service/PositionService.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/position/service/PositionService.java
@@ -25,7 +25,7 @@ public class PositionService {
     @Transactional(readOnly = true)
     public String getPositionNameById(Long positionId) {
         Position position = positionRepository.findById(positionId)
-                .orElseThrow(() -> new CustomException(ErrorCode.POSITION_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_POSITION));
         return position.getName();
     }
 }

--- a/recruit-service/src/main/resources/application.yml
+++ b/recruit-service/src/main/resources/application.yml
@@ -26,9 +26,9 @@ server:
 
 springdoc:
   api-docs:
-    path: /recruit/v3/api-docs
+    path: /recruits/v3/api-docs
   swagger-ui:
-    path: /recruit/swagger-ui.html
+    path: /recruits/swagger-ui.html
 
 jwt:
   secret: ${JWT_SECRET}

--- a/recruit-service/src/main/resources/application.yml
+++ b/recruit-service/src/main/resources/application.yml
@@ -45,4 +45,4 @@ meet-service:
   url: http://meet-service.meet-service:8080
 
 board-service:
-  hrl: http://board-service.board-service:8080
+  url: http://board-service.board-service:8080


### PR DESCRIPTION
### 🔍️ 이번 PR의 목적
- 지원 수락 기능 개발

### ✨ 핵심 변경 내용
-  Feign 오류 응답을 CustomException으로 매핑하는 ErrorDecoder 추가

### 📝 기타 참고 사항
- BoardInternalController에서 validateUserInBoard 호출 시
(boardId, userId) → (userId, boardId) 로 순서가 잘못 전달되고 있었음.

기존: validateUserInBoard(boardId, userId)
변경: validateUserInBoard(userId, boardId)

서비스 메서드 시그니처와 일치하도록 수정하여 정상 동작 보장.
