### PR TITLE
feat: 유저 권한별 접근 설정

### DIFF
--- a/board-service/src/main/java/com/paassible/boardservice/board/controller/BoardController.java
+++ b/board-service/src/main/java/com/paassible/boardservice/board/controller/BoardController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 

--- a/board-service/src/main/java/com/paassible/boardservice/config/SecurityConfig.java
+++ b/board-service/src/main/java/com/paassible/boardservice/config/SecurityConfig.java
@@ -1,11 +1,13 @@
 package com.paassible.boardservice.config;
 
+import com.paassible.common.security.exception.CustomAccessDeniedHandler;
 import com.paassible.common.security.exception.CustomAuthenticationEntryPoint;
 import com.paassible.common.security.jwt.JwtAuthenticationFilter;
 import com.paassible.common.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,10 +18,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -34,10 +38,9 @@ public class SecurityConfig {
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 // 인증 실패 시
-                .exceptionHandling(
-                        exceptionHandler ->
-                                exceptionHandler.authenticationEntryPoint(
-                                        customAuthenticationEntryPoint))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
 
                 // 인가 설정
                 .authorizeHttpRequests(auth -> auth

--- a/chat-service/src/main/java/com/paassible/chatservice/config/SecurityConfig.java
+++ b/chat-service/src/main/java/com/paassible/chatservice/config/SecurityConfig.java
@@ -1,11 +1,13 @@
 package com.paassible.chatservice.config;
 
+import com.paassible.common.security.exception.CustomAccessDeniedHandler;
 import com.paassible.common.security.exception.CustomAuthenticationEntryPoint;
 import com.paassible.common.security.jwt.JwtAuthenticationFilter;
 import com.paassible.common.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,10 +18,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,10 +36,9 @@ public class SecurityConfig {
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-                .exceptionHandling(
-                        exceptionHandler ->
-                                exceptionHandler.authenticationEntryPoint(
-                                        customAuthenticationEntryPoint))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/common/src/main/java/com/paassible/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/paassible/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import com.paassible.common.response.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -70,6 +72,12 @@ public class GlobalExceptionHandler {
             HttpRequestMethodNotSupportedException ex) {
         return ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
                 .body(ApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    @ExceptionHandler({ AccessDeniedException.class, AuthorizationDeniedException.class })
+    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(Exception ex) {
+        return ResponseEntity.status(ErrorCode.ACCESS_DENIED.getHttpStatus())
+                .body(ApiResponse.fail(ErrorCode.ACCESS_DENIED));
     }
 
     @ExceptionHandler(Exception.class)

--- a/common/src/main/java/com/paassible/common/response/ErrorCode.java
+++ b/common/src/main/java/com/paassible/common/response/ErrorCode.java
@@ -28,6 +28,8 @@ public enum ErrorCode implements BaseResponseCode {
     TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "A005", "인증 토큰이 존재하지 않습니다."),
     INVALID_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "A006", "유효하지 않은 Authorization 헤더입니다"),
     GOOGLE_TOKEN_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "A007", "구글 응답에 access_token이 없습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A008", "권한이 부족합니다"),
+    TERMS_NOT_AGREED(HttpStatus.FORBIDDEN, "A009", "약관에 동의하지 않았습니다"),
 
     // board
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "존재하지 않는 보드입니다."),

--- a/common/src/main/java/com/paassible/common/response/SuccessCode.java
+++ b/common/src/main/java/com/paassible/common/response/SuccessCode.java
@@ -15,7 +15,8 @@ public enum SuccessCode implements BaseResponseCode {
     // user
     LOGIN(HttpStatus.OK, "LOGIN", "로그인이 완료되었습니다."),
     LOGOUT(HttpStatus.OK, "LOGOUT", "로그아웃이 완료되었습니다."),
-    WITHDRAWAL(HttpStatus.OK, "WITHDRAWAL", "회원 탈퇴되었습니다.");
+    WITHDRAWAL(HttpStatus.OK, "WITHDRAWAL", "회원 탈퇴되었습니다."),
+    AGREE(HttpStatus.OK, "AGREE", "약관 동의가 완료되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/common/src/main/java/com/paassible/common/security/config/WebConfig.java
+++ b/common/src/main/java/com/paassible/common/security/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.paassible.common.security.config;
+
+import com.paassible.common.security.interceptor.TermsCheckInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final TermsCheckInterceptor termsCheckInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(termsCheckInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/users/auth/**", "/users/test/**", "/users/terms");
+    }
+}

--- a/common/src/main/java/com/paassible/common/security/dto/UserJwtDto.java
+++ b/common/src/main/java/com/paassible/common/security/dto/UserJwtDto.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 public class UserJwtDto {
     private Long userId;
     private Role role;
-    private boolean termsAgreed;
+    private boolean agreedToTerms;
 
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));

--- a/common/src/main/java/com/paassible/common/security/dto/UserJwtDto.java
+++ b/common/src/main/java/com/paassible/common/security/dto/UserJwtDto.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 public class UserJwtDto {
     private Long userId;
     private Role role;
+    private boolean termsAgreed;
 
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));

--- a/common/src/main/java/com/paassible/common/security/exception/CustomAccessDeniedHandler.java
+++ b/common/src/main/java/com/paassible/common/security/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.paassible.common.security.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.paassible.common.response.ApiResponse;
+import com.paassible.common.response.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<Void> errorResponse = ApiResponse.fail(ErrorCode.ACCESS_DENIED);
+
+        mapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/common/src/main/java/com/paassible/common/security/interceptor/TermsCheckInterceptor.java
+++ b/common/src/main/java/com/paassible/common/security/interceptor/TermsCheckInterceptor.java
@@ -1,0 +1,49 @@
+package com.paassible.common.security.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.paassible.common.response.ApiResponse;
+import com.paassible.common.response.ErrorCode;
+import com.paassible.common.security.dto.UserJwtDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class TermsCheckInterceptor implements HandlerInterceptor {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws IOException {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return true;
+        }
+
+        UserJwtDto dto = (UserJwtDto) auth.getPrincipal();
+
+        if (!dto.isTermsAgreed()) {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            response.setContentType("application/json;charset=UTF-8");
+
+            ApiResponse<Void> errorResponse =
+                    ApiResponse.fail(ErrorCode.TERMS_NOT_AGREED);
+
+            mapper.writeValue(response.getWriter(), errorResponse);
+
+            return false;
+        }
+        return true;
+    }
+}

--- a/common/src/main/java/com/paassible/common/security/jwt/JwtAuthenticationFilter.java
+++ b/common/src/main/java/com/paassible/common/security/jwt/JwtAuthenticationFilter.java
@@ -27,8 +27,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && jwtUtil.validateToken(token)) {
             Long id = jwtUtil.getUserId(token);
             Role role = Role.valueOf(jwtUtil.getRole(token));
+            boolean termsAgreed = jwtUtil.getTermsAgreed(token);
 
-            UserJwtDto user = new UserJwtDto(id, role);
+            UserJwtDto user = new UserJwtDto(id, role, termsAgreed);
 
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(

--- a/common/src/main/java/com/paassible/common/security/jwt/JwtAuthenticationFilter.java
+++ b/common/src/main/java/com/paassible/common/security/jwt/JwtAuthenticationFilter.java
@@ -27,9 +27,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && jwtUtil.validateToken(token)) {
             Long id = jwtUtil.getUserId(token);
             Role role = Role.valueOf(jwtUtil.getRole(token));
-            boolean termsAgreed = jwtUtil.getTermsAgreed(token);
+            boolean agreedToTerms = jwtUtil.getAgreedToTerms(token);
 
-            UserJwtDto user = new UserJwtDto(id, role, termsAgreed);
+            UserJwtDto user = new UserJwtDto(id, role, agreedToTerms);
 
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(

--- a/common/src/main/java/com/paassible/common/security/jwt/JwtUtil.java
+++ b/common/src/main/java/com/paassible/common/security/jwt/JwtUtil.java
@@ -38,11 +38,11 @@ public class JwtUtil {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String createAccessToken(Long userId, Role role, boolean termsAgreed) {
+    public String createAccessToken(Long userId, Role role, boolean agreedToTerms) {
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim("role", role.name())
-                .claim("termsAgreed", termsAgreed)
+                .claim("agreedToTerms", agreedToTerms)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
                 .signWith(key)
@@ -96,13 +96,13 @@ public class JwtUtil {
                 .get("role", String.class);
     }
 
-    public boolean getTermsAgreed(String token) {
+    public boolean getAgreedToTerms(String token) {
         return Jwts.parser()
                 .verifyWith(key)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload()
-                .get("termsAgreed", Boolean.class);
+                .get("agreedToTerms", Boolean.class);
     }
 
     public long getAccessTokenValidity() {

--- a/common/src/main/java/com/paassible/common/security/jwt/JwtUtil.java
+++ b/common/src/main/java/com/paassible/common/security/jwt/JwtUtil.java
@@ -38,10 +38,11 @@ public class JwtUtil {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String createAccessToken(Long userId, Role role) {
+    public String createAccessToken(Long userId, Role role, boolean termsAgreed) {
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim("role", role.name())
+                .claim("termsAgreed", termsAgreed)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
                 .signWith(key)
@@ -93,6 +94,15 @@ public class JwtUtil {
                 .parseSignedClaims(token)
                 .getPayload()
                 .get("role", String.class);
+    }
+
+    public boolean getTermsAgreed(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("termsAgreed", Boolean.class);
     }
 
     public long getAccessTokenValidity() {

--- a/recruit-service/src/main/java/com/paassible/recruitservice/config/SecurityConfig.java
+++ b/recruit-service/src/main/java/com/paassible/recruitservice/config/SecurityConfig.java
@@ -1,11 +1,13 @@
 package com.paassible.recruitservice.config;
 
+import com.paassible.common.security.exception.CustomAccessDeniedHandler;
 import com.paassible.common.security.exception.CustomAuthenticationEntryPoint;
 import com.paassible.common.security.jwt.JwtAuthenticationFilter;
 import com.paassible.common.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,10 +18,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,10 +36,9 @@ public class SecurityConfig {
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-                .exceptionHandling(
-                        exceptionHandler ->
-                                exceptionHandler.authenticationEntryPoint(
-                                        customAuthenticationEntryPoint))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/user-service/src/main/java/com/paassible/userservice/auth/controller/AuthController.java
+++ b/user-service/src/main/java/com/paassible/userservice/auth/controller/AuthController.java
@@ -26,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
     private final AuthService authService;
-    private final GoogleOAuthService googleOAuthService;
 
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "현재 가진 토큰을 이용해 엑세스 토큰을 재발급합니다.")

--- a/user-service/src/main/java/com/paassible/userservice/auth/service/AuthService.java
+++ b/user-service/src/main/java/com/paassible/userservice/auth/service/AuthService.java
@@ -37,9 +37,9 @@ public class AuthService {
 
         Long userId = user.getId();
         Role role = user.getRole();
-        boolean termsAgreed = user.isTermsAgreed();
+        boolean agreedToTerms = user.isAgreedToTerms();
 
-        String newAccessToken = jwtUtil.createAccessToken(userId, role, termsAgreed);
+        String newAccessToken = jwtUtil.createAccessToken(userId, role, agreedToTerms);
         String newRefreshToken = jwtUtil.createRefreshToken(userId);
 
         response.addCookie(jwtUtil.createRefreshTokenCookie(newRefreshToken));
@@ -74,9 +74,9 @@ public class AuthService {
 
         User user = userService.getUser(userId);
         Role role = user.getRole();
-        boolean termsAgreed = user.isTermsAgreed();
+        boolean agreedToTerms = user.isAgreedToTerms();
 
-        String newAccessToken = jwtUtil.createAccessToken(userId, role, termsAgreed);
+        String newAccessToken = jwtUtil.createAccessToken(userId, role, agreedToTerms);
         String newRefreshToken = jwtUtil.createRefreshToken(userId);
 
         response.addCookie(jwtUtil.createRefreshTokenCookie(newRefreshToken));

--- a/user-service/src/main/java/com/paassible/userservice/auth/service/AuthService.java
+++ b/user-service/src/main/java/com/paassible/userservice/auth/service/AuthService.java
@@ -37,8 +37,9 @@ public class AuthService {
 
         Long userId = user.getId();
         Role role = user.getRole();
+        boolean termsAgreed = user.isTermsAgreed();
 
-        String newAccessToken = jwtUtil.createAccessToken(userId, role);
+        String newAccessToken = jwtUtil.createAccessToken(userId, role, termsAgreed);
         String newRefreshToken = jwtUtil.createRefreshToken(userId);
 
         response.addCookie(jwtUtil.createRefreshTokenCookie(newRefreshToken));
@@ -73,8 +74,9 @@ public class AuthService {
 
         User user = userService.getUser(userId);
         Role role = user.getRole();
+        boolean termsAgreed = user.isTermsAgreed();
 
-        String newAccessToken = jwtUtil.createAccessToken(userId, role);
+        String newAccessToken = jwtUtil.createAccessToken(userId, role, termsAgreed);
         String newRefreshToken = jwtUtil.createRefreshToken(userId);
 
         response.addCookie(jwtUtil.createRefreshTokenCookie(newRefreshToken));

--- a/user-service/src/main/java/com/paassible/userservice/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/paassible/userservice/config/SecurityConfig.java
@@ -1,11 +1,13 @@
 package com.paassible.userservice.config;
 
+import com.paassible.common.security.exception.CustomAccessDeniedHandler;
 import com.paassible.common.security.exception.CustomAuthenticationEntryPoint;
 import com.paassible.common.security.jwt.JwtAuthenticationFilter;
 import com.paassible.common.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,10 +18,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -34,10 +38,9 @@ public class SecurityConfig {
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 // 인증 실패 시
-                .exceptionHandling(
-                        exceptionHandler ->
-                                exceptionHandler.authenticationEntryPoint(
-                                        customAuthenticationEntryPoint))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
 
                 // 인가 설정
                 .authorizeHttpRequests(auth -> auth

--- a/user-service/src/main/java/com/paassible/userservice/user/controller/UserController.java
+++ b/user-service/src/main/java/com/paassible/userservice/user/controller/UserController.java
@@ -4,8 +4,8 @@ import com.paassible.common.response.ApiResponse;
 import com.paassible.common.response.SuccessCode;
 import com.paassible.common.security.dto.UserJwtDto;
 import com.paassible.common.security.jwt.JwtUtil;
-import com.paassible.common.security.jwt.Role;
 import com.paassible.userservice.user.dto.UserResponse;
+import com.paassible.userservice.user.entity.User;
 import com.paassible.userservice.user.service.UserService;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,17 +40,12 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.WITHDRAWAL));
     }
 
-    /*
-    @PostMapping("/role")
-    @Operation(summary = "역할 설정", description = "유저가 자신의 역할을 설정한다.")
-    public ResponseEntity<ApiResponse<UserResponse>> setRole(
-            @RequestBody RoleRequest request, HttpServletResponse httpServletResponse) {
-
-        UserResponse response = userService.setUserRole(request, httpServletResponse);
-
-        return ResponseEntity.ok(ApiResponse.success(CommonSuccessCode.OK, response));
+    @PatchMapping("/terms")
+    @Operation(summary = "약관 동의", description = "회원가입 후 약관에 동의한다.")
+    public ResponseEntity<ApiResponse<Void>> setRole(@AuthenticationPrincipal UserJwtDto user) {
+        userService.agreeTerms(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.AGREE));
     }
-     */
 
     @Hidden
     @GetMapping("/internal/{userId}")
@@ -62,7 +57,8 @@ public class UserController {
     @GetMapping("/test/{userId}")
     @Operation(summary = "유저 엑세스 토큰 발급(테스트용)")
     public ResponseEntity<String> getCurrentUser(@PathVariable Long userId) {
-        String accessToken = jwtUtil.createAccessToken(userId, Role.MEMBER);
+        User user = userService.getUser(userId);
+        String accessToken = jwtUtil.createAccessToken(userId, user.getRole(), user.isTermsAgreed());
         return ResponseEntity.ok(accessToken);
     }
 }

--- a/user-service/src/main/java/com/paassible/userservice/user/entity/User.java
+++ b/user-service/src/main/java/com/paassible/userservice/user/entity/User.java
@@ -28,6 +28,8 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    private boolean termsAgreed;
+
     private boolean deleted;
 
     public void updateRole(Role newRole) {
@@ -36,5 +38,9 @@ public class User {
 
     public void updateDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    public void updateTermsAgreed(boolean termsAgreed) {
+        this.termsAgreed = termsAgreed;
     }
 }

--- a/user-service/src/main/java/com/paassible/userservice/user/entity/User.java
+++ b/user-service/src/main/java/com/paassible/userservice/user/entity/User.java
@@ -28,7 +28,7 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    private boolean termsAgreed;
+    private boolean agreedToTerms;
 
     private boolean deleted;
 
@@ -40,7 +40,7 @@ public class User {
         this.deleted = deleted;
     }
 
-    public void updateTermsAgreed(boolean termsAgreed) {
-        this.termsAgreed = termsAgreed;
+    public void updateAgreedToTerms(boolean termsAgreed) {
+        this.agreedToTerms = termsAgreed;
     }
 }

--- a/user-service/src/main/java/com/paassible/userservice/user/service/UserService.java
+++ b/user-service/src/main/java/com/paassible/userservice/user/service/UserService.java
@@ -46,7 +46,7 @@ public class UserService {
                                             .email(info.getEmail())
                                             .nickname(info.getName())
                                             .role(Role.PENDING)
-                                            .termsAgreed(false)
+                                            .agreedToTerms(false)
                                             .deleted(false)
                                             .build();
                             return userRepository.save(newUser);
@@ -62,7 +62,7 @@ public class UserService {
     @Transactional
     public void agreeTerms(Long userId) {
         User user = getUser(userId);
-        user.updateTermsAgreed(true);
+        user.updateAgreedToTerms(true);
     }
 
     // 프로필 설정 시에 확인 누르면 바로 같이 role 업데이트 되도록

--- a/user-service/src/main/java/com/paassible/userservice/user/service/UserService.java
+++ b/user-service/src/main/java/com/paassible/userservice/user/service/UserService.java
@@ -46,6 +46,7 @@ public class UserService {
                                             .email(info.getEmail())
                                             .nickname(info.getName())
                                             .role(Role.PENDING)
+                                            .termsAgreed(false)
                                             .deleted(false)
                                             .build();
                             return userRepository.save(newUser);
@@ -57,16 +58,17 @@ public class UserService {
         User user = userRepository.findById(userId).orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
         user.updateDeleted(true);
     }
-    /*
-       @Transactional
-       public UserResponse setUserRole(RoleRequest roleRequest, HttpServletResponse response) {
-           Long userId = SecurityUtils.getCurrentUserId();
 
-           User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-           user.updateRole(roleRequest.getRole());
+    @Transactional
+    public void agreeTerms(Long userId) {
+        User user = getUser(userId);
+        user.updateTermsAgreed(true);
+    }
 
-           return UserResponse.from(user);
-       }
-
-    */
+    // 프로필 설정 시에 확인 누르면 바로 같이 role 업데이트 되도록
+    @Transactional
+    public void updateRoleToMember(Long userId) {
+        User user = getUser(userId);
+        user.updateRole(Role.MEMBER);
+    }
 }


### PR DESCRIPTION
### 🔍️ 이번 PR의 목적
-유저 권한별 접근 설정

### ✨ 핵심 변경 내용
- User 엔티티에 agreedToTerms 약관 동의 여부를 저장하는 변수 추가
- Interceptor를 이용해 동의하지 않는 경우 에러 발생
- accesstoken에 agreedToTerms 추가

### 📝 기타 참고 사항
- role에 따라 api에 접근하는 설정 해야함
